### PR TITLE
enable to use PEM feature without nanojson nor tomitribe-util

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,81 @@
+#
+# Copyright (c) 2021, 2022 - Yupiik SAS - https://www.yupiik.com
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Github CI
+
+on: [push, pull_request]
+
+env:
+  MAVEN_OPTS: -Dmaven.repo.local=/home/runner/work/churchkey/churchkey/.m2 -Dmaven.artifact.threads=256
+
+jobs:
+  build:
+    name: Main Build
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone
+        uses: actions/checkout@v3
+      - name: Cache Maven Repository
+        uses: actions/cache@v3
+        with:
+          path: /home/runner/work/churchkey/churchkey/.m2
+          key: m2_repository
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '17'
+      - run: echo "JAVA_HOME_17=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up JDK 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - run: echo "JAVA_HOME_8=$JAVA_HOME" >> $GITHUB_ENV
+      - name: Set up Toolchain
+        shell: bash
+        run: |
+          mkdir -p $HOME/.m2 \
+          && cat << EOF > $HOME/.m2/toolchains.xml
+          <?xml version="1.0" encoding="UTF8"?>
+          <toolchains>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <vendor>zulu</vendor>
+                <version>8</version>
+              </provides>
+              <configuration>
+                <jdkHome>${{ env.JAVA_HOME_8 }}</jdkHome>
+              </configuration>
+            </toolchain>
+            <toolchain>
+              <type>jdk</type>
+              <provides>
+                <vendor>zulu</vendor>
+                <version>17</version>
+              </provides>
+              <configuration>
+                <jdkHome>${{ env.JAVA_HOME_17 }}</jdkHome>
+              </configuration>
+            </toolchain>
+          </toolchains>
+          EOF
+      - name: Build
+        run: mvn package surefire:test@pem-dep-free -Dm2.location=/home/runner/work/churchkey/churchkey/.m2
+      - name: Remove Snapshots Before Caching
+        run: find /home/runner/work/churchkey/churchkey/.m2 -name '*SNAPSHOT' | xargs rm -Rf
+

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,12 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# idea
+.idea
+*.iml
+*.ipr
+*.iws
+
+# Maven
+target

--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,17 @@
-# Churchkey
+= Churchkey
+:churchkey-version: 0.14
+
+image::https://img.shields.io/maven-central/v/org.tomitribe/churchkey?color=e77224&label=Last%20Release&logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAAEAAAAA/CAMAAABnwz74AAAAilBMVEUAAADqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyXqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyXqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyTqcyRL2uskAAAALXRSTlMA7+SJTZT9OyIG2Z71dt/MRScZDQgE+bOXcC0U8j/FwbyljFlQ0o9lVIJrijavM7/TAAAB4ElEQVRIx+2W2ZaiMBRFE9oOCTMog2iBinPV/f/fa5QG7o3doDyz3zw5a8vKtMKGCVIO4J0lm4bKBDzhx2mC39DiBGwCXwI6rNUEwR4QiwkCAwu+h7srKeVSDx0ssNkAi50jhEj8i5okUHbXKqMpAhvVCjzZ2/cEAWBcNGLhgRvDxHlVBX8nLSUCT+F9hDAZ4scXdcTd+OHaAiHsayGahJLssHYgq39sBBV8oeK9GzNCFC+9rn0cFrALb8JTjtOqb+9GBCxyU9/fV4qE577NY6Ze5mCUrG8L9boKHwsW2j74SJAo7dT67xx7F10T8eMk9oYi0rqR+eCHHtQwgZZfTXItElFzWmv/b5ai6W2zzT+XwevijZQyYhrXBH1rRM6vaMKcDSHJAu/odWkXfnpfskHOQDD/34xDsyGPcXyCNxe4skS7LQxX6XeqPuGv3EgtVe8Iouu65vKcw0BoXzouiG9OE4lSMlYCxViNCr4B0EYQoJGPCcIEpQcGOosxwRqn1ucCetfyWTALZsEsmAWzYFgQfCjY6gLZFgua39v8QAU2UHzWsiZ50omv9OkkOemJoH/VW3jgQF77+L0fYINzwQ9KZNijJ6TJqTY6nHiDZdOH39L1n7mRHkkuM++Z7+r4D2hVbEujx/8RAAAAAElFTkSuQmCC[]
+// TODO once CI is setup image::https://github.com/tomitribe/churchkey/workflows/Github%20CI/badge.svg[Github Action Build]
 
 Churchkey is a Java library that can parse and export public and private key files in several formats including:
 
-  - JSON Web Key (JWK)
+- JSON Web Key (JWK)
   - PEM
   - OpenSSH
   - SSH2
 
-## Reading keys
+== Reading keys
 
 *Step 1* Pass the bytes of the key file to Churchkey. No need to tell Churchkey what kind of key it is.
 
@@ -42,7 +46,7 @@ Assert.assertTrue(key.getKey() instanceof RSAPublicKey);
 
 See the complete link:https://github.com/tomitribe/churchkey/blob/master/src/test/java/org/supertribe/ExampleTest.java#L39[source]
 
-## Writing/Converting Keys
+== Writing/Converting Keys
 
 The following will read (decode) a PEM file and then convert (encode) it to a JWK format
 
@@ -70,7 +74,7 @@ JsonAsserts.assertJson(expected, jwk);
 
 See the complete link:https://github.com/tomitribe/churchkey/blob/master/src/test/java/org/supertribe/Pem2JwkTest.java#L48[source]
 
-## Get the Public key from a Private key
+== Get the Public key from a Private key
 
 The following will read (decode) a private key PEM file and then obtain and write out the public PEM.
 
@@ -102,10 +106,10 @@ assertEquals("" +
 See the complete link:https://github.com/tomitribe/churchkey/blob/master/src/test/java/org/supertribe/PublicFromPrivateTest.java#L41[source]
 
 
-## Supported Key Formats
+== Supported Key Formats
 Churchkey is a Java library that can read RSA and DSA that look like any of the following:
 
-### JSON Web Key (JWK)
+=== JSON Web Key (JWK)
 
 [source,json]
 ----
@@ -122,7 +126,9 @@ Churchkey is a Java library that can read RSA and DSA that look like any of the 
 }
 ----
 
-### Various PEM Files
+NOTE: requires `nanojson` library.
+
+=== Various PEM Files
 ----
 -----BEGIN RSA PRIVATE KEY-----
 MIICXQIBAAKBgQCyzNurU19lqnYhx5QI72sIX1lh8cTehTmboC+DLG7UuaUHqs09
@@ -169,12 +175,12 @@ eDVsA5nc7qTnsSgULXTxwHSF286IJdco5kasaJm4Xurlm3V+2oiTugraBsi1J0Ht
 -----END PUBLIC KEY-----
 ----
 
-### OpenSSH
+=== OpenSSH
 
 Common locations for these would be in:
 
- - `~/.ssh/id_rsa` (PEM format shown above)
- - `~/.ssh/id_rsa.pub` (`ssh-` format shown here)
+- `~/.ssh/id_rsa` (PEM format shown above)
+- `~/.ssh/id_rsa.pub` (`ssh-` format shown here)
 
 ----
 ssh-dss AAAAB3NzaC1kc3MAAACBAN9w84QLHWmzl/gY2Xh/CnM7hfTsUl6Z89NUmhOFfs/wzO54Pl84qKjWmlhJO9VGFwsMRbw0EqGgS1eBngv+DR/eMAN+0KnLTPTNEajKP/ibTRf3sI3Rf7UTYhSp7W5r5FB8TN39chg9JQUR7c0ALOdbyDL8d+yhB5SzLEAWQ4QTAAAAFQCcu9GKMJJyX8go6w1gn93Xi1/EDwAAAIBJYC9VGyg80b7DF8+fHKfezGEjjRgJOVMJQA946vA3A+cntFUU+Y1LayXJ2y... dblevins@mingus.lan
@@ -184,7 +190,7 @@ ssh-dss AAAAB3NzaC1kc3MAAACBAN9w84QLHWmzl/gY2Xh/CnM7hfTsUl6Z89NUmhOFfs/wzO54Pl84
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQCyzNurU19lqnYhx5QI72sIX1lh8cTehTmboC+DLG7UuaUHqs096M754HtP2IiHFcIQqwYNzHgKmjmfGdbk9JBkz/DNeDVsA5nc7qTnsSgULXTxwHSF286IJdco5kasaJm4Xurlm3V+2oiTugraBsi1J0Ht0OtHgJIlIaGxK7mY/Q== dblevins@mingus.lan
 ----
 
-### SSH2
+=== SSH2
 
 Commonly mistaken for PEM, but different.
 
@@ -197,14 +203,30 @@ wHSF286IJdco5kasaJm4Xurlm3V+2oiTugraBsi1J0Ht0OtHgJIlIaGxK7mY/Q==
 ---- END SSH2 PUBLIC KEY ----
 ----
 
-## Maven Coordinates
+== Maven Coordinates
 
 [source,xml]
 ----
 <dependency>
   <groupId>org.tomitribe</groupId>
   <artifactId>churchkey</artifactId>
-  <version>0.14</version>
+  <version>${churchkey.version}</version>
 </dependency>
 ----
 
+Note that on Java 17, you can exclude all transitive dependencies if you only use PEM format:
+
+[source,xml]
+----
+<dependency>
+  <groupId>org.tomitribe</groupId>
+  <artifactId>churchkey</artifactId>
+  <version>${churchkey.version}</version>
+  <exclusions>
+    <exclusion>
+      <groupId>*</groupId>
+      <artifactId>*</artifactId>
+    </exclusion>
+  </exclusions>
+</dependency>
+----

--- a/pom.xml
+++ b/pom.xml
@@ -174,10 +174,39 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M7</version>
+        <executions>
+          <execution>
+            <id>pem-dep-free</id>
+            <phase>none</phase>
+            <goals>
+              <goal>test</goal>
+            </goals>
+            <configuration>
+              <forkCount>1</forkCount>
+              <jdkToolchain>
+                <version>17</version>
+              </jdkToolchain>
+              <failIfNoTests>true</failIfNoTests>
+              <includes>
+                <include>**/pem/*Test.java</include>
+              </includes>
+              <systemPropertyVariables>
+                <test.json>false</test.json>
+                <test.tomitribe-util>false</test.tomitribe-util>
+              </systemPropertyVariables>
+              <classpathDependencyExcludes>
+                <classpathDependencyExclude>com.grack:nanojson</classpathDependencyExclude>
+                <classpathDependencyExclude>org.tomitribe:tomitribe-util</classpathDependencyExclude>
+              </classpathDependencyExcludes>
+            </configuration>
+          </execution>
+        </executions>
         <configuration>
           <forkCount>4</forkCount>
           <reuseForks>true</reuseForks>
           <argLine>-Xmx128m</argLine>
+          <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
       <plugin>
@@ -192,6 +221,7 @@
             </goals>
             <configuration>
               <minimizeJar>true</minimizeJar>
+              <dependencyReducedPomLocation>${project.build.directory}/reduced-pom.xml</dependencyReducedPomLocation>
               <relocations>
                 <relocation>
                   <pattern>com.grack.nanojson</pattern>

--- a/src/main/java/io/churchkey/Keys.java
+++ b/src/main/java/io/churchkey/Keys.java
@@ -16,11 +16,10 @@
  */
 package io.churchkey;
 
-import org.tomitribe.util.IO;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.interfaces.DSAPrivateKey;
@@ -69,7 +68,7 @@ public class Keys {
      * @return a {@link Key} instance that has metadata and wraps the parsed {@link java.security.Key}
      */
     public static Key decode(final File file) throws IOException {
-        return decode(IO.readBytes(file));
+        return decode(Files.readAllBytes(file.toPath()));
     }
 
     /**
@@ -119,7 +118,7 @@ public class Keys {
      * @return a {@link Key} instance that has metadata and wraps the parsed {@link java.security.Key}
      */
     public static List<Key> decodeSet(final File file) throws IOException {
-        return decodeSet(IO.readBytes(file));
+        return decodeSet(Files.readAllBytes(file.toPath()));
     }
 
     /**

--- a/src/main/java/io/churchkey/asn1/Asn1Dump.java
+++ b/src/main/java/io/churchkey/asn1/Asn1Dump.java
@@ -16,14 +16,16 @@
 package io.churchkey.asn1;
 
 import io.churchkey.util.Pem;
-import org.tomitribe.util.IO;
 import org.tomitribe.util.Pipe;
-import org.tomitribe.util.PrintString;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+
+import static io.churchkey.util.Printers.printer;
 
 public class Asn1Dump {
 
@@ -32,7 +34,7 @@ public class Asn1Dump {
 
     public static void print(final byte[] bytes) throws IOException {
         final File der = File.createTempFile("der", ".dump");
-        IO.copy(bytes, der);
+        Files.write(der.toPath(), bytes);
 
         final ProcessBuilder builder = new ProcessBuilder("openssl", "asn1parse", "-i", "-inform", "DER", "-in", der.getAbsolutePath(), "-dump");
         final Process process = builder.start();
@@ -53,13 +55,13 @@ public class Asn1Dump {
 
         if (bytes[0] == '-' && bytes[1] == '-'){
             final Pem pem = Pem.parse(bytes);
-            IO.copy(pem.getData(), der);
+            Files.write(der.toPath(), pem.getData());
         } else {
-            IO.copy(bytes, der);
+            Files.write(der.toPath(), bytes);
         }
 
-        final PrintString err = new PrintString();
-        final PrintString out = new PrintString();
+        final PrintStream out = printer();
+        final PrintStream err = printer();
         final ProcessBuilder builder = new ProcessBuilder("openssl", "asn1parse", "-i", "-inform", "DER", "-in", der.getAbsolutePath(), "-dump");
         final Process process = builder.start();
         final Future<Pipe> o = Pipe.pipe(process.getInputStream(), out);

--- a/src/main/java/io/churchkey/asn1/Oid.java
+++ b/src/main/java/io/churchkey/asn1/Oid.java
@@ -15,9 +15,6 @@
  */
 package io.churchkey.asn1;
 
-import org.tomitribe.util.Hex;
-import org.tomitribe.util.Join;
-
 import java.io.ByteArrayOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -28,6 +25,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static io.churchkey.util.Utils.fromHexString;
+import static io.churchkey.util.Utils.toHexString;
+import static java.util.stream.Collectors.joining;
 
 /**
  * OIDs are encoded using Variable-Length Quantity.
@@ -65,11 +66,11 @@ public class Oid {
 
     @Override
     public String toString() {
-        return Join.join(".", oid);
+        return oid.stream().map(Object::toString).collect(joining("."));
     }
 
     public String toHex() {
-        return Hex.toString(toBytes());
+        return toHexString(toBytes());
     }
 
     public byte[] toBytes() {
@@ -115,7 +116,7 @@ public class Oid {
     }
 
     public static Oid fromHex(final String hex) throws IOException {
-        final byte[] bytes = Hex.fromString(hex);
+        final byte[] bytes = fromHexString(hex);
         return fromBytes(bytes);
     }
 

--- a/src/main/java/io/churchkey/ec/Curve.java
+++ b/src/main/java/io/churchkey/ec/Curve.java
@@ -16,7 +16,6 @@
 package io.churchkey.ec;
 
 import io.churchkey.asn1.Oid;
-import org.tomitribe.util.Hex;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -39,6 +38,7 @@ import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 import static io.churchkey.asn1.Oid.oid;
+import static io.churchkey.util.Utils.fromHexString;
 
 /**
  * Curves supplied via https://neuromancer.sk/std/
@@ -1001,7 +1001,7 @@ public enum Curve {
 
     private static ECParameterSpec prime(final String fp, final String a, final String b, final String x, final String y, final String n, final String seed, final int h) {
         return new ECParameterSpec(
-                new EllipticCurve(new ECFieldFp(bi(fp)), bi(a), bi(b), Hex.fromString(seed)),
+                new EllipticCurve(new ECFieldFp(bi(fp)), bi(a), bi(b), fromHexString(seed)),
                 new ECPoint(bi(x), bi(y)),
                 bi(n), h);
     }
@@ -1015,7 +1015,7 @@ public enum Curve {
 
     private static ECParameterSpec binary(final int m, int[] ks, final String a, final String b, final String x, final String y, final String n, final String seed, final int h) {
         return new ECParameterSpec(
-                new EllipticCurve(new ECFieldF2m(m, ks), bi(a), bi(b), Hex.fromString(seed)),
+                new EllipticCurve(new ECFieldF2m(m, ks), bi(a), bi(b), fromHexString(seed)),
                 new ECPoint(bi(x), bi(y)),
                 bi(n), h);
     }

--- a/src/main/java/io/churchkey/ec/ECParameterSpecs.java
+++ b/src/main/java/io/churchkey/ec/ECParameterSpecs.java
@@ -15,10 +15,7 @@
  */
 package io.churchkey.ec;
 
-import org.tomitribe.util.Hex;
-import org.tomitribe.util.Join;
-import org.tomitribe.util.PrintString;
-
+import java.io.PrintStream;
 import java.math.BigInteger;
 import java.security.spec.ECField;
 import java.security.spec.ECFieldF2m;
@@ -26,6 +23,10 @@ import java.security.spec.ECFieldFp;
 import java.security.spec.ECParameterSpec;
 import java.util.ArrayList;
 import java.util.List;
+
+import static io.churchkey.util.Printers.printer;
+import static io.churchkey.util.Utils.toHexString;
+import static java.util.stream.Collectors.joining;
 
 public class ECParameterSpecs {
     private ECParameterSpecs() {
@@ -57,7 +58,7 @@ public class ECParameterSpecs {
     }
 
     public static String toString(final ECParameterSpec spec) {
-        final PrintString out = new PrintString();
+        final PrintStream out = printer();
         final String x = hex(spec.getGenerator().getAffineX());
         final String y = hex(spec.getGenerator().getAffineY());
         final String a = hex(spec.getCurve().getA());
@@ -94,7 +95,7 @@ public class ECParameterSpecs {
                     "    \"%s\",\n" +
                     "    \"%s\",\n" +
                     "    \"%s\",\n" +
-                    "    %s), %s)\n", m, Join.join(", ", terms), a, b, x, y, n, cofactor, null);
+                    "    %s), %s)\n", m, terms.stream().map(Object::toString).collect(joining(", ")), a, b, x, y, n, cofactor, null);
         }
 
 
@@ -102,6 +103,6 @@ public class ECParameterSpecs {
     }
 
     public static String hex(final BigInteger bi) {
-        return Hex.toString(bi.toByteArray()).toUpperCase();
+        return toHexString(bi.toByteArray()).toUpperCase();
     }
 }

--- a/src/main/java/io/churchkey/ec/EcPoints.java
+++ b/src/main/java/io/churchkey/ec/EcPoints.java
@@ -16,10 +16,11 @@
 package io.churchkey.ec;
 
 import io.churchkey.util.Bytes;
-import org.tomitribe.util.Hex;
 
 import java.math.BigInteger;
 import java.security.spec.ECPoint;
+
+import static io.churchkey.util.Utils.toHexString;
 
 public class EcPoints {
     private EcPoints() {
@@ -32,7 +33,7 @@ public class EcPoints {
 
         if (bytes[0] != (byte) 0x04) {
             final byte[] format = {bytes[0]};
-            throw new UnsupportedOperationException("Only uncompressed EC points are supported.  Found EC point compression format of " + Hex.toString(format) + " (hex)");
+            throw new UnsupportedOperationException("Only uncompressed EC points are supported.  Found EC point compression format of " + toHexString(format) + " (hex)");
         }
 
         final int length = bytes.length - 1;

--- a/src/main/java/io/churchkey/ssh/KeyInput.java
+++ b/src/main/java/io/churchkey/ssh/KeyInput.java
@@ -15,13 +15,14 @@
  */
 package io.churchkey.ssh;
 
-import org.tomitribe.util.PrintString;
-
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.math.BigInteger;
+
+import static io.churchkey.util.Printers.printer;
 
 public class KeyInput extends DataInputStream {
 
@@ -30,7 +31,7 @@ public class KeyInput extends DataInputStream {
     }
 
     public String readAuthMagic() throws IOException {
-        final PrintString string = new PrintString();
+        final PrintStream string = printer();
         int read = this.read();
         while (read != '\000') {
             if (read == -1) throw new EOFException();

--- a/src/main/java/io/churchkey/util/Pem.java
+++ b/src/main/java/io/churchkey/util/Pem.java
@@ -16,10 +16,10 @@
 package io.churchkey.util;
 
 import lombok.Data;
-import org.tomitribe.util.PrintString;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +28,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import static io.churchkey.util.Printers.printer;
 
 @Data
 public class Pem {
@@ -98,7 +100,7 @@ public class Pem {
     }
 
     public String format() {
-        final PrintString out = new PrintString();
+        final PrintStream out = printer();
         out.println(header);
 
         for (final Map.Entry<String, String> entry : attributes.entrySet()) {

--- a/src/main/java/io/churchkey/util/Printers.java
+++ b/src/main/java/io/churchkey/util/Printers.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021 Tomitribe and community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.churchkey.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.function.Supplier;
+
+public final class Printers {
+    private static final Supplier<PrintStream> FACTORY;
+    static {
+        Supplier<PrintStream> factory;
+        try {
+            final Constructor<? extends PrintStream> constructor = Printers.class.getClassLoader()
+                    .loadClass("org.tomitribe.util.PrintString")
+                    .asSubclass(PrintStream.class)
+                    .getConstructor();
+            factory = () -> {
+                try {
+                    return constructor.newInstance();
+                } catch (final InstantiationException | IllegalAccessException e) {
+                    throw new IllegalStateException(e);
+                } catch (final InvocationTargetException e) {
+                    final Throwable ex = e.getTargetException();
+                    if (RuntimeException.class.isInstance(ex)) {
+                        throw RuntimeException.class.cast(ex);
+                    }
+                    throw new IllegalStateException(ex);
+                }
+            };
+        } catch (final Error | Exception e) {
+            factory = SimplePrinter::new;
+        }
+        FACTORY = factory;
+    }
+
+    private Printers() {
+        // no-op
+    }
+
+    public static PrintStream printer() {
+        return FACTORY.get();
+    }
+
+    private static class SimplePrinter extends PrintStream {
+        public SimplePrinter() {
+            super(new ByteArrayOutputStream(), true);
+        }
+
+        @Override
+        public String toString() {
+            flush();
+            return out.toString();
+        }
+    }
+}

--- a/src/test/java/io/churchkey/Generate.java
+++ b/src/test/java/io/churchkey/Generate.java
@@ -16,11 +16,10 @@
  */
 package io.churchkey;
 
-import org.tomitribe.util.IO;
-
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -31,11 +30,11 @@ public class Generate {
         final File dir = new File("/Users/dblevins/work/tomitribe/churchkey/src/test/resources/der");
 
         for (final File file : dir.listFiles()) {
-            final DataInputStream stream = new DataInputStream(IO.read(file));
-            final int anInt = stream.readInt();
-
-            stream.close();
-            IO.copy(Integer.toBinaryString(anInt).getBytes(), new File(file.getAbsolutePath() + ".bin"));
+            final int anInt;
+            try (final DataInputStream stream = new DataInputStream(Files.newInputStream(file.toPath()))) {
+                anInt = stream.readInt();
+            }
+            Files.write(new File(file.getAbsolutePath() + ".bin").toPath(), Integer.toBinaryString(anInt).getBytes());
         }
     }
 
@@ -55,8 +54,8 @@ public class Generate {
 
         for (int i = 0; i < 100; i++) {
             final KeyPair keyPair = rsa.generateKeyPair();
-            IO.copy(keyPair.getPublic().getEncoded(), new File(dir, algorithm + "-" + size + "-public-pkcs8.der." + i));
-            IO.copy(keyPair.getPrivate().getEncoded(), new File(dir, algorithm + "-" + size + "-private-pkcs8.der." + i));
+            Files.write(new File(dir, algorithm + "-" + size + "-public-pkcs8.der." + i).toPath(), keyPair.getPublic().getEncoded());
+            Files.write(new File(dir, algorithm + "-" + size + "-private-pkcs8.der." + i).toPath(), keyPair.getPrivate().getEncoded());
         }
     }
 

--- a/src/test/java/io/churchkey/JsonAsserts.java
+++ b/src/test/java/io/churchkey/JsonAsserts.java
@@ -18,7 +18,6 @@ package io.churchkey;
 
 import org.junit.Assert;
 import org.tomitribe.util.IO;
-import org.tomitribe.util.PrintString;
 
 import javax.json.Json;
 import javax.json.JsonArray;
@@ -29,8 +28,11 @@ import javax.json.JsonReader;
 import javax.json.JsonValue;
 import javax.json.stream.JsonGenerator;
 import javax.json.stream.JsonGeneratorFactory;
+import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
+
+import static io.churchkey.util.Printers.printer;
 
 public class JsonAsserts {
 
@@ -52,7 +54,7 @@ public class JsonAsserts {
         final Map<String, Object> properties = new HashMap<>(1);
         properties.put(JsonGenerator.PRETTY_PRINTING, true);
         final JsonGeneratorFactory jgf = Json.createGeneratorFactory(properties);
-        final PrintString out = new PrintString();
+        final PrintStream out = printer();
         final JsonGenerator jg = jgf.createGenerator(out);
         jg.write(jsonObject);
         jg.flush();

--- a/src/test/java/io/churchkey/Resource.java
+++ b/src/test/java/io/churchkey/Resource.java
@@ -16,9 +16,10 @@
  */
 package io.churchkey;
 
-import org.tomitribe.util.IO;
-
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 
 public class Resource {
@@ -48,7 +49,16 @@ public class Resource {
     public byte[] bytes(final String name) throws IOException {
         final URL privateDerUrl = new URL(base, name);
         requireResource(privateDerUrl, name);
-        return IO.readBytes(privateDerUrl);
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (final InputStream stream = privateDerUrl.openStream();
+             final OutputStream out = baos) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = stream.read(buffer, 0, buffer.length)) >= 0) {
+                out.write(buffer, 0, read);
+            }
+        }
+        return baos.toByteArray();
     }
 
     private static URL requireResource(final URL resource, final String name) {

--- a/src/test/java/io/churchkey/ec/CurveAsserts.java
+++ b/src/test/java/io/churchkey/ec/CurveAsserts.java
@@ -22,6 +22,7 @@ import java.security.spec.ECFieldF2m;
 import java.security.spec.ECFieldFp;
 import java.security.spec.ECParameterSpec;
 
+import static io.churchkey.util.Utils.toHexString;
 import static org.junit.Assert.assertEquals;
 
 public class CurveAsserts {
@@ -44,8 +45,8 @@ public class CurveAsserts {
     }
 
     public static void assertBigInt(final BigInteger expected, final BigInteger actual) {
-        final String e1 = Hex.toString(expected.toByteArray()).replaceFirst("^00", "");
-        final String a1 = Hex.toString(actual.toByteArray()).replaceFirst("^00", "");
+        final String e1 = toHexString(expected.toByteArray()).replaceFirst("^00", "");
+        final String a1 = toHexString(actual.toByteArray()).replaceFirst("^00", "");
         assertEquals(e1, a1);
     }
 }

--- a/src/test/java/io/churchkey/pem/BeginEcPrivateKeyTest.java
+++ b/src/test/java/io/churchkey/pem/BeginEcPrivateKeyTest.java
@@ -24,7 +24,6 @@ import org.junit.runners.Parameterized;
 import io.churchkey.Key;
 import io.churchkey.Resource;
 import io.churchkey.Skip;
-import org.tomitribe.util.Hex;
 
 import java.io.IOException;
 import java.security.interfaces.ECPrivateKey;
@@ -32,6 +31,7 @@ import java.security.interfaces.ECPublicKey;
 import java.security.spec.ECParameterSpec;
 import java.util.List;
 
+import static io.churchkey.util.Utils.toHexString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -89,7 +89,7 @@ public class BeginEcPrivateKeyTest {
 
         { // assert private key integer
             final byte[] expected = resource.bytes("private.pkcs1." + openSslCurveName + "." + format + ".txt");
-            assertEquals(new String(expected), Hex.toString(privateKey.getS().toByteArray()));
+            assertEquals(new String(expected), toHexString(privateKey.getS().toByteArray()));
         }
 
         { // assert curve parameters

--- a/src/test/java/io/churchkey/pem/BeginPrivateKeyDsaTest.java
+++ b/src/test/java/io/churchkey/pem/BeginPrivateKeyDsaTest.java
@@ -19,12 +19,12 @@ import org.junit.Test;
 import io.churchkey.Key;
 import io.churchkey.Keys;
 import io.churchkey.Resource;
-import org.tomitribe.util.Hex;
 
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.interfaces.DSAPrivateKey;
 
+import static io.churchkey.util.Utils.toHexString;
 import static org.junit.Assert.assertEquals;
 
 public class BeginPrivateKeyDsaTest {
@@ -119,7 +119,7 @@ public class BeginPrivateKeyDsaTest {
     }
 
     private String toHex(final BigInteger bigInteger) {
-        return Hex.toString(bigInteger.toByteArray()).toUpperCase().replaceAll("^00", "");
+        return toHexString(bigInteger.toByteArray()).toUpperCase().replaceAll("^00", "");
     }
 
     @Test

--- a/src/test/java/io/churchkey/pem/BeginPrivateKeyEcTest.java
+++ b/src/test/java/io/churchkey/pem/BeginPrivateKeyEcTest.java
@@ -26,7 +26,6 @@ import io.churchkey.Key;
 import io.churchkey.Keys;
 import io.churchkey.Resource;
 import io.churchkey.ec.ECParameterSpecs;
-import org.tomitribe.util.Hex;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -40,6 +39,8 @@ import java.security.spec.ECParameterSpec;
 import java.util.Base64;
 import java.util.List;
 
+import static io.churchkey.util.Utils.fromHexString;
+import static io.churchkey.util.Utils.toHexString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -97,7 +98,7 @@ public class BeginPrivateKeyEcTest {
         { // assert private key integer
             final byte[] expected = resource.bytes("private.pkcs8." + openSslCurveName + "." + format + ".txt");
 
-            final BigInteger i = new BigInteger(1, Hex.fromString(new String(expected)));
+            final BigInteger i = new BigInteger(1, fromHexString(new String(expected)));
             final BigInteger s = privateKey.getS();
             assertEquals(i, s);
         }
@@ -128,7 +129,7 @@ public class BeginPrivateKeyEcTest {
         // Assert what we read is identical
         final ECPrivateKey expectedKey = (ECPrivateKey) expected.getKey();
         final ECPrivateKey actualKey = (ECPrivateKey) actual.getKey();
-        assertEquals(Hex.toString(expectedKey.getS().toByteArray()), Hex.toString(actualKey.getS().toByteArray()));
+        assertEquals(toHexString(expectedKey.getS().toByteArray()), toHexString(actualKey.getS().toByteArray()));
         ECParameterSpecs.equals(expectedKey.getParams(), actualKey.getParams());
     }
 

--- a/src/test/java/io/churchkey/pem/BeginPrivateKeyRsaTest.java
+++ b/src/test/java/io/churchkey/pem/BeginPrivateKeyRsaTest.java
@@ -19,13 +19,13 @@ import org.junit.Test;
 import io.churchkey.Key;
 import io.churchkey.Keys;
 import io.churchkey.Resource;
-import org.tomitribe.util.Hex;
 
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.interfaces.RSAPublicKey;
 
+import static io.churchkey.util.Utils.toHexString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -230,7 +230,7 @@ public class BeginPrivateKeyRsaTest {
     }
 
     private String toHex(final BigInteger bigInteger) {
-        return Hex.toString(bigInteger.toByteArray()).toUpperCase().replaceAll("^00", "");
+        return toHexString(bigInteger.toByteArray()).toUpperCase().replaceAll("^00", "");
     }
 
 }

--- a/src/test/java/io/churchkey/pem/BeginPrivateKeyTest.java
+++ b/src/test/java/io/churchkey/pem/BeginPrivateKeyTest.java
@@ -18,11 +18,11 @@ package io.churchkey.pem;
 
 import io.churchkey.Decoder;
 import io.churchkey.KeyAsserts;
+import org.junit.Assume;
 import org.junit.Test;
 import io.churchkey.Key;
 import io.churchkey.Keys;
 import io.churchkey.Resource;
-import org.tomitribe.util.Hex;
 
 import java.math.BigInteger;
 import java.security.KeyFactory;
@@ -31,6 +31,7 @@ import java.security.interfaces.RSAPrivateCrtKey;
 import java.security.spec.ECFieldFp;
 import java.security.spec.PKCS8EncodedKeySpec;
 
+import static io.churchkey.util.Utils.toHexString;
 import static org.junit.Assert.assertEquals;
 
 public class BeginPrivateKeyTest {
@@ -172,6 +173,8 @@ public class BeginPrivateKeyTest {
      */
     @Test
     public void trickyEncoding() throws Exception {
+        Assume.assumeTrue(Boolean.parseBoolean(System.getProperty("test.json", "true")));
+
         final String jwk = "{" +
                 "\"d\":\"i-cfA2QsqM293T8lSVHK0XHXya21y6Fxv6x2cuHFjeg\"," +
                 "\"crv\":\"P-256\",\"y\":\"rod-94CZV31COEG_BBA3BL9k7tLEMl7fsikNlFEJ7q4\"," +
@@ -189,7 +192,7 @@ public class BeginPrivateKeyTest {
     }
 
     private String toHex(final BigInteger bigInteger) {
-        return Hex.toString(bigInteger.toByteArray()).toUpperCase().replaceAll("^00", "");
+        return toHexString(bigInteger.toByteArray()).toUpperCase().replaceAll("^00", "");
     }
 
     public void assertDecode(final Decoder decoder, final Resource resource) throws Exception {

--- a/src/test/java/io/churchkey/pem/BeginPublicKeyTest.java
+++ b/src/test/java/io/churchkey/pem/BeginPublicKeyTest.java
@@ -89,7 +89,7 @@ public class BeginPublicKeyTest {
             final String exported = new String(key.encode(Key.Format.OPENSSH));
             assertEquals(new String(resource.bytes("public.openssh")).replace(" dblevins@mingus.lan", ""), exported);
         }
-        { // Export to JWK
+        if (Boolean.parseBoolean(System.getProperty("test.json", "true"))) { // Export to JWK
             final String exported = new String(key.encode(Key.Format.JWK));
             JsonAsserts.assertJson(new String(resource.bytes("public.jwk")), exported);
         }

--- a/src/test/java/io/churchkey/pem/BeginRsaPublicKeyTest.java
+++ b/src/test/java/io/churchkey/pem/BeginRsaPublicKeyTest.java
@@ -87,7 +87,7 @@ public class BeginRsaPublicKeyTest {
             final String exported = new String(key.encode(Key.Format.OPENSSH));
             assertEquals(new String(resource.bytes("public.openssh")).replace(" dblevins@mingus.lan", ""), exported);
         }
-        { // Export to JWK
+        if (Boolean.parseBoolean(System.getProperty("test.json", "true"))) { // Export to JWK
             final String exported = new String(key.encode(Key.Format.JWK));
             JsonAsserts.assertJson(new String(resource.bytes("public.jwk")), exported);
         }

--- a/src/test/java/io/churchkey/pem/OpenSslEcCurvesTest.java
+++ b/src/test/java/io/churchkey/pem/OpenSslEcCurvesTest.java
@@ -20,6 +20,7 @@ import io.churchkey.asn1.Asn1Dump;
 import io.churchkey.ec.Curve;
 import io.churchkey.ec.CurveAsserts;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -115,6 +116,7 @@ public class OpenSslEcCurvesTest {
         final byte[] expected = resource.bytes(openSslCurveName + "-params.pem");
         final byte[] actual = BeginEcParameters.encode(curve.getParameterSpec());
 
+        Assume.assumeTrue(Boolean.parseBoolean(System.getProperty("test.tomitribe-util", "true")));
         Assert.assertEquals(Asn1Dump.dump(expected), Asn1Dump.dump(actual));
         assertEquals(new String(expected), new String(actual));
     }


### PR DESCRIPTION
Goal to use it "dep free" is to lighten integrations but also make it more shebang/jshell friendly in scripts (less deps = less setup).